### PR TITLE
Add Flask app with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+.Python
+.env
+.venv
+pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # Creative Career Constellation
+
+## Development Setup
+
+Install dependencies and run tests:
+
+```bash
+pip install -r requirements.txt
+pytest
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,12 @@
+from flask import Flask, request, jsonify
+
+app = Flask(__name__)
+
+@app.route('/chat', methods=['POST'])
+def chat():
+    data = request.get_json() or {}
+    message = data.get('message', '')
+    return jsonify({'response': f'You said: {message}'})
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/frontend.py
+++ b/frontend.py
@@ -1,0 +1,12 @@
+import requests
+
+def send_message(base_url: str, message: str) -> str:
+    resp = requests.post(f"{base_url}/chat", json={"message": message})
+    resp.raise_for_status()
+    data = resp.json()
+    return data.get('response', '')
+
+if __name__ == '__main__':
+    import sys
+    base = sys.argv[1] if len(sys.argv) > 1 else 'http://localhost:5000'
+    print(send_message(base, 'Hello'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask
+pytest
+pytest-flask
+requests

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,16 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from app import app
+
+@pytest.fixture
+def client():
+    with app.test_client() as client:
+        yield client
+
+def test_chat_endpoint(client):
+    response = client.post('/chat', json={'message': 'hi'})
+    assert response.status_code == 200
+    assert response.get_json() == {'response': 'You said: hi'}

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -1,0 +1,29 @@
+import os
+import sys
+from types import SimpleNamespace
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import frontend
+from app import app
+
+@pytest.fixture
+def client():
+    with app.test_client() as client:
+        yield client
+
+class MockResponse:
+    def __init__(self, data):
+        self._data = data
+    def raise_for_status(self):
+        pass
+    def json(self):
+        return self._data
+
+def test_frontend_integration(client, monkeypatch):
+    def fake_post(url, json):
+        resp = client.post('/chat', json=json)
+        return MockResponse(resp.get_json())
+    monkeypatch.setattr(frontend.requests, 'post', fake_post)
+    resp = frontend.send_message('http://localhost:5000', 'hello')
+    assert resp == 'You said: hello'


### PR DESCRIPTION
## Summary
- add minimal Flask chat app
- add frontend script for sending chat messages
- provide unit tests for the Flask endpoint and integration test for the frontend script
- include requirements file and instructions in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68695722bf6883268fea2b7dfda6846b