### PR TITLE
Improve API error handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -50,11 +50,10 @@ def chat():
                 max_tokens=200,
             )
             reply_content = response.choices[0].message["content"]
+            return jsonify({"reply": reply_content})
         except Exception as e:
-            reply_content = json.dumps({
-                "error": f"Error contacting OpenAI: {e}",
-                "question": "Could you try again?"
-            })
+            return jsonify({"error": f"Error contacting OpenAI: {e}"}), 502
+
     elif HF_API_TOKEN:
         prompt = (
             "You are a friendly career advisor helping children create a "
@@ -80,16 +79,12 @@ def chat():
                     reply_content = data[0].get("generated_text", "")
                 else:
                     reply_content = json.dumps(data)
+                return jsonify({"reply": reply_content})
             else:
-                reply_content = json.dumps({
-                    "error": f"HuggingFace API error {r.status_code}",
-                    "question": "Could you try again?"
-                })
+                return jsonify({"error": f"HuggingFace API error {r.status_code}"}), 502
         except Exception as e:
-            reply_content = json.dumps({
-                "error": f"Error contacting HuggingFace: {e}",
-                "question": "Could you try again?"
-            })
+            return jsonify({"error": f"Error contacting HuggingFace: {e}"}), 502
+
     else:
         # Offline fallback
         reply_content = json.dumps({
@@ -97,8 +92,8 @@ def chat():
             "skills": ["camera operation", "storytelling"],
             "question": "What else do you enjoy?"
         })
+        return jsonify({"reply": reply_content})
 
-    return jsonify({"reply": reply_content})
 
 
 if __name__ == '__main__':

--- a/static/js/constellation.js
+++ b/static/js/constellation.js
@@ -68,6 +68,10 @@ function sendMessage() {
 
     axios.post('/api/chat', {messages})
         .then(resp => {
+            if (resp.data.error) {
+                addMessage('assistant', resp.data.error);
+                return;
+            }
             const reply = resp.data.reply;
             addMessage('assistant', reply);
             messages.push({role: 'assistant', content: reply});
@@ -86,7 +90,10 @@ function sendMessage() {
         })
         .catch(err => {
             console.error(err);
-            addMessage('assistant', 'There was an error contacting the AI service.');
+            const msg = err.response && err.response.data && err.response.data.error
+                ? err.response.data.error
+                : 'There was an error contacting the AI service.';
+            addMessage('assistant', msg);
         });
 }
 


### PR DESCRIPTION
## Summary
- handle failing API calls with JSON `{error: ...}` responses and status codes
- display these error messages in the front-end

## Testing
- `pytest -q`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6869572133fc8326aedadd70484e14e9